### PR TITLE
SE-716 Ensured that all APIs are built with useQueryString set to tru…

### DIFF
--- a/sdk/client/client.ts
+++ b/sdk/client/client.ts
@@ -167,6 +167,8 @@ export class Client {
     lusid.APIS.forEach((api: any) => {
       // Create a new instance of the api endpoint
       let apiInstance = new api(this.basePath)
+      // As per docs at (https://github.com/request/request) use `foo=bar&foo=baz` format always
+      apiInstance.useQuerystring = true
       // Get the name of the API
       let apiName: string = apiInstance.constructor.name
       // Shorten the api name slightly by removing API at the end

--- a/sdk/test/tutorials/createPortfolio.test.ts
+++ b/sdk/test/tutorials/createPortfolio.test.ts
@@ -1,41 +1,61 @@
 // Require the LUSID SDK and libraries
 import {
-  CreateTransactionPortfolioRequest, Portfolio } from "../../api";
+  CreateTransactionPortfolioRequest, CurrencyAndAmount, TransactionRequest
+} from "../../api";
 
 import { client } from './clientBuilder'
 import { IncomingMessage } from "http";
 import { LusidProblemDetails } from "../../model/models";
 const uuid4 = require('uuid/v4')
 
+let scope = uuid4()
 
-function createTransactionPortfolio(
-  scope: string,
-  createRequest: CreateTransactionPortfolioRequest
-  ) :Promise<Portfolio> {
-    return new Promise((resolve, reject) => {
-      client.api.transactionPortfolios.createPortfolio(
-        scope,
-        createRequest
-      )
-      .then((res: {response: IncomingMessage; body: Portfolio}) => resolve(res.body))
-      .catch((err: {response: IncomingMessage; body: LusidProblemDetails}) => reject(err))
-    })
-  }
-
-var createRequest = new CreateTransactionPortfolioRequest()
+let createRequest = new CreateTransactionPortfolioRequest()
 createRequest.displayName = "UK Equities"
 createRequest.code = "UKEQTY"
 createRequest.baseCurrency = "GBP"
+createRequest.created = new Date(2020, 1, 1, 12, 0, 0)
+
+let transactionRequest = new TransactionRequest()
+transactionRequest.instrumentIdentifiers = {"Instrument/default/Currency": "GBP"}
+transactionRequest.type = "FundsIn"
+transactionRequest.transactionDate = "2020-12-15T13:00:00Z"
+transactionRequest.settlementDate = "2020-12-17T13:00:00Z"
+transactionRequest.totalConsideration = new CurrencyAndAmount()
+transactionRequest.totalConsideration.amount = 100
+transactionRequest.totalConsideration.currency = "GBP"
+transactionRequest.units = 100
+transactionRequest.transactionCurrency = "GBP"
+transactionRequest.transactionId = "1_-5207"
 
 describe('Create portfolios', () => {
   it('Should create a portfolio', (done) => {
-    createTransactionPortfolio(uuid4(), createRequest)
-    .then((res) => {
-      console.log(res)
-      done()
-    })
-    .catch((err) => console.log(err.response.statusCode, err.response.statusMessage))
+    client.api.transactionPortfolios.createPortfolio(
+        scope,
+        createRequest
+    )
+    .then(() => done())
+    .catch((err: {response: IncomingMessage; body: LusidProblemDetails}) => done(err.body))
   })
+
+  it('Should upsert a transaction', (done) => {
+    client.api.transactionPortfolios.upsertTransactions(
+        scope,
+        createRequest.code,
+        [transactionRequest])
+    .then(() => done())
+    .catch((err: {response: IncomingMessage; body: LusidProblemDetails}) => done(err.body))
+  })
+
+  it('Should cancel a transaction', (done) => {
+    client.api.transactionPortfolios.cancelTransactions(
+        scope,
+        createRequest.code,
+        [transactionRequest.transactionId])
+    .then(() => done())
+    .catch((err: {response: IncomingMessage; body: LusidProblemDetails}) => done(err.body))
+  })
+
 })
 
 export {};


### PR DESCRIPTION
…e so that in the case of there being multiple values for a given parameter in the query string the format of 'foo=bar&foo=baz' is used instead of the default 'foo[0]=bar&foo[1]=baz' which is not supported by the LUSID API. Added a test on the Cancel Transactions API where this issue was first identified to ensure that it is working as expected

# Pull Request Checklist

- [x] Read the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] Tests pass
- [x] Raised the PR against the `develop` branch

# Description of the PR

Describe the code changes for the reviewers, explain the solution you have provided and how it fixes the issue
