### PR TITLE
Feature/CTECH-336: Add npm install command when running the test container

### DIFF
--- a/sdk/Dockerfile
+++ b/sdk/Dockerfile
@@ -16,4 +16,4 @@ ENV FBN_CLIENT_ID ${FBN_CLIENT_ID}
 ENV FBN_CLIENT_SECRET ${FBN_CLIENT_SECRET}
 ENV FBN_LUSID_API_URL ${FBN_LUSID_API_URL}
 
-ENTRYPOINT ["sh","-c", "npm run build && npm run test"]
+ENTRYPOINT ["sh","-c", "npm install && npm run build && npm run test"]


### PR DESCRIPTION
# Pull Request Checklist

- [ ] Read the [contributing guidelines](../blob/master/docs/CONTRIBUTING.md)
- [ ] Tests pass
- [ ] Raised the PR against the `develop` branch

# Description of the PR

As of right now the "npm install" command is only run during the creation of the test image (ie: in the Dockerfile it has RUN npm install). However, this results in it installing the dependencies that were in the package.json file when the image was constructed out of the master branch. We need it to run the npm install using whatever package.json file is in the current branch.  
